### PR TITLE
Add GitHub Actions workflow to sync repo labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -51,13 +51,11 @@
 # Skill level
 - name: good first issue
   color: "159818"
-  description:
-    Clearly described and easy to accomplish.  Good for beginners to the
-    project
+  description: Clearly described and easy to accomplish. Good for beginners to the project.
 
 - name: good second issue
   color: 5319e7
-  description: Clearly described, educational, but less trivial than "good first issue"
+  description: Clearly described, educational, but less trivial than "good first issue".
 
 # Status
 - name: needs info
@@ -70,4 +68,4 @@
 
 - name: needs triage
   color: 7b9ad8
-  description: "Awaiting triage by a Dask Czar."
+  description: "Awaiting triage by a Dask maintainer."

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,50 @@
+- color: 006b75
+  description: ""
+  name: array
+- color: 0052cc
+  description: ""
+  name: bag
+- color: d93f0b
+  description: ""
+  name: community
+- color: 55b3c1
+  description: ""
+  name: config
+- color: "000000"
+  description: ""
+  name: core
+- color: fbca04
+  description: ""
+  name: dataframe
+- color: 4f6edd
+  description: ""
+  name: delayed
+- color: bebaf4
+  description: ""
+  name: discussion
+- color: f9d0c4
+  description: ""
+  name: documentation
+- color: ffcce7
+  description: Intermittent failures on CI.
+  name: flaky test
+- color: "159818"
+  description:
+    Clearly described and easy to accomplish.  Good for beginners to the
+    project
+  name: good first issue
+- color: 5319e7
+  description: Clearly described, educational, but less trivial than "good first issue"
+  name: good second issue
+- color: e99695
+  description: ""
+  name: io
+- color: f4e49a
+  description: ""
+  name: needs info
+- color: 64db8e
+  description: ""
+  name: scheduler
+- color: D3D3D3
+  description: ""
+  name: stale

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,50 +1,73 @@
-- color: 006b75
+# Type
+- name: community
+  color: d93f0b
   description: ""
-  name: array
-- color: 0052cc
+
+- name: discussion
+  color: bebaf4
   description: ""
-  name: bag
-- color: d93f0b
+
+# Area
+- name: array
+  color: 006b75
   description: ""
-  name: community
-- color: 55b3c1
+
+- name: bag
+  color: 0052cc
   description: ""
-  name: config
-- color: "000000"
+
+- name: config
+  color: 55b3c1
   description: ""
-  name: core
-- color: fbca04
+
+- name: core
+  color: "000000"
   description: ""
-  name: dataframe
-- color: 4f6edd
+
+- name: dataframe
+  color: fbca04
   description: ""
-  name: delayed
-- color: bebaf4
+
+- name: delayed
+  color: 4f6edd
   description: ""
-  name: discussion
-- color: f9d0c4
+
+- name: documentation
+  color: f9d0c4
   description: ""
-  name: documentation
-- color: ffcce7
+
+- name: io
+  color: e99695
+  description: ""
+
+- name: scheduler
+  color: 64db8e
+  description: ""
+
+- name: flaky test
+  color: ffcce7
   description: Intermittent failures on CI.
-  name: flaky test
-- color: "159818"
+
+# Skill level
+- name: good first issue
+  color: "159818"
   description:
     Clearly described and easy to accomplish.  Good for beginners to the
     project
-  name: good first issue
-- color: 5319e7
+
+- name: good second issue
+  color: 5319e7
   description: Clearly described, educational, but less trivial than "good first issue"
-  name: good second issue
-- color: e99695
+
+# Status
+- name: needs info
+  color: f4e49a
   description: ""
-  name: io
-- color: f4e49a
+
+- name: stale
+  color: D3D3D3
   description: ""
-  name: needs info
-- color: 64db8e
-  description: ""
-  name: scheduler
-- color: D3D3D3
-  description: ""
-  name: stale
+
+- name: needs triage
+  color: 7b9ad8
+  description: "Awaiting triage by a Dask Czar."

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,22 @@
+---
+name: Sync labels in the declarative way
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repository:
+          - dask/dask
+    steps:
+      - uses: actions/checkout@1.0.0
+      - uses: micnncim/action-label-syncer@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.ORG_GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ matrix.repository }}
+        with:
+          manifest: .github/labels.yml

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -13,7 +13,7 @@ jobs:
         repository:
           - dask/dask
     steps:
-      - uses: actions/checkout@1.0.0
+      - uses: actions/checkout@v2
       - uses: micnncim/action-label-syncer@v1
         env:
           GITHUB_TOKEN: ${{ secrets.ORG_GITHUB_TOKEN }}


### PR DESCRIPTION
This GitHub Actions workflow will sync issue/pr labels with a YAML list stored at `.github/labels.yml` in this repo.

This PR is just a test. I've exported the labels from dask/dask and configured the action to only modify dask/dask, so when it runs nothing should change, but it should run successfully.

This action will use an org level access token which belongs to @dask-bot that I have already configured into the repo secrets.

Next steps will be to update the manifest to represent the labels being discussed in dask/community#50 and to bring more repos into the matrix. I just wanted to start cautiously.