### PR TITLE
Switch to fork of label sync

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -14,9 +14,8 @@ jobs:
           - dask/dask
     steps:
       - uses: actions/checkout@v2
-      - uses: micnncim/action-label-syncer@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.ORG_GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ matrix.repository }}
+      - uses: jacobtomlinson/action-label-syncer@override-repo
         with:
           manifest: .github/labels.yml
+          repository: ${{ matrix.repository }}
+          token: ${{ secrets.ORG_GITHUB_TOKEN }}


### PR DESCRIPTION
Looks like it's not possible to override the built in `GITHUB_` env vars. Therefore I've forked the action and added the option to override them with inputs.

While waiting for my PR (micnncim/action-label-syncer#43) to be reviewed I'll just switch this to my fork for testing.