### PR TITLE
Don't run label sync from forks

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -6,8 +6,9 @@ on:
       - master
 
 jobs:
-  build:
+  sync-labels:
     runs-on: ubuntu-latest
+    if: github.repository == 'dask/.github'
     strategy:
       matrix:
         repository:


### PR DESCRIPTION
Currently the label sync workflow also runs on forks when there is a push on their master branch. The forks don't have the `ORG_GITHUB_TOKEN` secret configured so the workflow will just fail and the user will probably get an annoying email.

This PR limits the workflow to just `dask/.github` and also renamed the job to be more descriptive.