### PR TITLE
Add high level question link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: General Question
+  - name: General Coding Question
     url: https://stackoverflow.com/questions/tagged/dask
     about: "If you have a question like *How do I filter a dask.dataframe?* then please ask on Stack Overflow using the #Dask tag."
+  - name: High Level Question
+    url: https://github.com/dask/dask/discussions/categories/q-a
+    about: "If you have a question like *How do I use Dask to help my company achieve X?* then please ask on GitHub Discussions."


### PR DESCRIPTION
From the discussion in dask/community#117 it seems that we have a Q&A section in the dask/dask repo for folks to ask high level questions. StackOverflow is for specific coding questions, so this is a place for more nebulous questions.

Updating the issue template to help direct folks to this place.