### PR TITLE
Add section on cluster dump

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -34,3 +34,15 @@ Bug reports that follow these guidelines are easier to diagnose, and so are ofte
 - Python version:
 - Operating System:
 - Install method (conda, pip, source):
+
+<!-- If you are reporting an issue such as scale stability, cluster deadlock.
+Please provide a cluster dump state with this issue, by running client.dump_cluster_state()
+
+https://distributed.dask.org/en/stable/api.html?highlight=dump_cluster_state#distributed.Client.dump_cluster_state
+
+-->
+
+<details>
+<summary>Cluster Dump State:</summary>
+
+</details>


### PR DESCRIPTION
This PR adds a section to the bug issue for users to fill with their `client.dump_cluster_state()`

Should this be another item in the environment? something like:

```
- Install method (conda, pip, source):
- Cluster dump state:
<details>
...
</details>
```

The PR should close https://github.com/dask/distributed/issues/5514