### PR TITLE
[DO NOT MERGE] More labels updates

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -3,18 +3,6 @@
   color: d93f0b
   description: "Something is broken"
 
-- name: Type:Needs Triage
-  color: bebaf4
-  description: "Awaiting triage"
-
-- name: Type:Needs Attention
-  color: e58b7e
-  description: "It's been a while since this was pushed on"
-
-- name: Type:Needs Info
-  color: bebaf4
-  description: "Needs further information"
-
 - name: Type:Discussion
   color: bebaf4
   description: "Discussing a topic with no specific actions yet"
@@ -30,6 +18,23 @@
 - name: Type:Testing/CI
   color: f4e49a
   description: "Unit tests and/or continuous integration"
+
+- name: Type:Upstream
+  color: 9D7B36
+  description: "Relating to upstream libraries"
+
+# Status
+- name: Status:Needs Triage
+  color: bebaf4
+  description: "Awaiting triage"
+
+- name: Status:Needs Attention
+  color: e58b7e
+  description: "It's been a while since this was pushed on"
+
+- name: Status:Needs Info
+  color: bebaf4
+  description: "Needs further information"
 
 # Area
 - name: Area:Array
@@ -48,7 +53,7 @@
   color: "000000"
   description: ""
 
-- name: Area:Daraframe
+- name: Area:Dataframe
   color: fbca04
   description: ""
 

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -16,7 +16,7 @@ jobs:
           - dask/distributed
     steps:
       - uses: actions/checkout@v2
-      - uses: jacobtomlinson/action-label-syncer@override-repo
+      - uses: micnncim/action-label-syncer@1.3.0
         with:
           manifest: .github/labels.yml
           repository: ${{ matrix.repository }}


### PR DESCRIPTION
Merging #7 was premature, but the action didn't run because it uses a fork where the branch has been deleted. :sweat_smile: 

This PR:
 - updates the action
 - changes some `"Type:"` to `"Status:"` which feels more natural to me
 - fixes a typo.
 - adds `"Type:Upstream"` 

Before this merges, someone (I volunteer) needs to go into dask and distributed and map the existing labels to the new labels. 