### PR TITLE
Add `packaging` label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -56,6 +56,10 @@
   color: 6f871c
   description: ""
 
+- name: packaging
+  color: 03DB41
+  description: "Related to packaging infrastructure (e.g. conda, PyPI)"
+
 # Skill level
 # prefixed with "good"
 - name: good first issue


### PR DESCRIPTION
Occasionally we get issues open which are exclusively related to packaging. These types of issues are distinct from other issue areas (e.g. `array`) and often require a specific skill set. This label is also generic enough that I think it makes sense to apply to all repos in the org. 

cc @jsignell @fjetter @jakirkham for thoughts 